### PR TITLE
Added the bundler-audit and gemsurance gems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,8 @@ inherit_from: .rubocop_todo.yml
 AllCops:
   DisabledByDefault: true
   TargetRubyVersion: 2.5
+  Exclude:
+  - tmp/**/*
 
 #################### Lint ################################
 

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,8 @@ group :development do
   gem 'bullet'
   gem 'binding_of_caller'
   gem 'better_errors'
+  gem 'bundler-audit', '0.6.0'
+  gem 'gemsurance', '0.9.0'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,9 @@ GEM
     bullet (5.9.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    bundler-audit (0.6.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     byebug (10.0.2)
     capybara (3.12.0)
       addressable
@@ -116,6 +119,11 @@ GEM
       et-orbi (~> 1.1, >= 1.1.6)
       raabro (~> 1.1)
     gemoji (3.0.0)
+    gems (0.8.3)
+    gemsurance (0.9.0)
+      bundler (~> 1.2)
+      gems (~> 0.8)
+      git (~> 1.2)
     get_process_mem (0.2.3)
     git (1.5.0)
     github-markup (3.0.2)
@@ -415,12 +423,14 @@ DEPENDENCIES
   brakeman
   bugsnag
   bullet
+  bundler-audit (= 0.6.0)
   byebug
   capybara
   dotenv-rails
   factory_bot
   faraday_middleware
   gemoji
+  gemsurance (= 0.9.0)
   git
   github-markup
   guard
@@ -474,4 +484,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.1
+   1.17.2


### PR DESCRIPTION
The bundler-audit gem flags security vulnerabilities.  The gemsurance gem flags outdated gem versions and insecure gem versions.  Running gemsurance generates files in the tmp directory that get flagged by RuboCop, and that's why I updated .rubocop.yml to exclude the tmp directory.